### PR TITLE
Aggiunti test per getConfigurazioneComponente e RELEASE_NOTES per la …

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,25 @@
+# Release Notes
+
+## 1.0.2 — 2026-05-06
+
+Release di manutenzione: aggiornamento dipendenze GovPay e potenziamento della pipeline di build/release.
+
+### Aggiornamenti dipendenze
+- `govpay-bom` aggiornato a **1.1.3** (parent BOM).
+- `govpay-common` aggiornato a **1.1.2**.
+
+### Pipeline
+- **SBOM CycloneDX**: aggiunto job `sbom` che genera l'SBOM aggregato (formati `json` + `xml`, schema 1.6) tramite `cyclonedx-maven-plugin`. Eseguito su push su `main`/tag o su richiesta esplicita (`vars.FORCE_SBOM_JOB`); disattivabile con `vars.DISABLE_SBOM_JOB`. L'SBOM viene incluso nel ZIP `release-reports` sotto `reports/sbom/`.
+- **OSV Scanner**: aggiunto job `osv-scan` (Google OSV Scanner) eseguito su `main`/tag con fallimento bloccante. Il report SARIF è incluso nel ZIP `release-reports` sotto `reports/osv/`.
+- **Cache OWASP Dependency-Check**: chiave basata sulla data e flag `NOUPDATE_FLAG` per saltare l'aggiornamento NVD quando la cache è della stessa giornata.
+- **Workflow `refresh-owasp-db`**: aggiornamento notturno della cache NVD per ridurre la latenza dei job di build.
+- **Reports ZIP unico**: tutti i report (OWASP, JaCoCo, OSV, licenze, SBOM) collezionati in `release-reports-<tag>.zip` allegato alla GitHub Release.
+- **Bump action GitHub**: `actions/checkout` v6, `actions/setup-java` v5, `actions/cache` v5, `actions/upload-artifact` e `actions/download-artifact` v7.
+- **Fix step "Zip SQL files"**: aggiunto `mkdir -p target` prima dello zip per evitare errori nel checkout pulito del job release.
+
+### Codice
+- `GdeService`: implementato il nuovo metodo astratto `getConfigurazioneComponente(ComponenteEvento, Giornale)` introdotto da `govpay-common` 1.1.2, con mapping per i componenti standard incluso `API_MAGGIOLI_JPPA`.
+- Aggiunti script SQL di svecchiamento delle tabelle Spring Batch (`spring-batch-cleanup.sql`) per tutti i database supportati (PostgreSQL, MySQL, Oracle, SQL Server, HSQLDB).
+
+### Compatibilità
+Nessuna breaking change. Aggiornamento drop-in rispetto alla 1.0.1.

--- a/src/test/java/it/govpay/maggioli/batch/gde/service/GdeServiceTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/gde/service/GdeServiceTest.java
@@ -26,8 +26,11 @@ import org.springframework.web.client.RestTemplate;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.govpay.common.client.model.Connettore;
+import it.govpay.common.configurazione.model.GdeInterfaccia;
+import it.govpay.common.configurazione.model.Giornale;
 import it.govpay.common.configurazione.service.ConfigurazioneService;
 import it.govpay.common.gde.GdeEventInfo;
+import it.govpay.gde.client.beans.ComponenteEvento;
 import it.govpay.gde.client.beans.NuovoEvento;
 import it.govpay.maggioli.batch.gde.mapper.EventoMaggioliMapper;
 
@@ -196,6 +199,49 @@ class GdeServiceTest {
         verify(eventoMaggioliMapper).createEventoOk(eq(COD_DOMINIO), eq("postPagamentiV2UsingPOST"), any(),
                 eq(DATA_START), eq(DATA_END));
         verify(restTemplate).postForEntity(eq(GDE_BASE_URL + "/eventi"), eq(evento), eq(Void.class));
+    }
+
+    @Test
+    @DisplayName("getConfigurazioneComponente should return correct GdeInterfaccia for each ComponenteEvento")
+    void testGetConfigurazioneComponenteMapping() {
+        Giornale giornale = new Giornale();
+        GdeInterfaccia apiPagoPA = new GdeInterfaccia();
+        GdeInterfaccia apiEnte = new GdeInterfaccia();
+        GdeInterfaccia apiPagamento = new GdeInterfaccia();
+        GdeInterfaccia apiRagioneria = new GdeInterfaccia();
+        GdeInterfaccia apiBackoffice = new GdeInterfaccia();
+        GdeInterfaccia apiPendenze = new GdeInterfaccia();
+        GdeInterfaccia apiBackendIO = new GdeInterfaccia();
+        GdeInterfaccia apiMaggioliJPPA = new GdeInterfaccia();
+        giornale.setApiPagoPA(apiPagoPA);
+        giornale.setApiEnte(apiEnte);
+        giornale.setApiPagamento(apiPagamento);
+        giornale.setApiRagioneria(apiRagioneria);
+        giornale.setApiBackoffice(apiBackoffice);
+        giornale.setApiPendenze(apiPendenze);
+        giornale.setApiBackendIO(apiBackendIO);
+        giornale.setApiMaggioliJPPA(apiMaggioliJPPA);
+
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_PAGOPA, giornale)).isSameAs(apiPagoPA);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_ENTE, giornale)).isSameAs(apiEnte);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_PAGAMENTO, giornale)).isSameAs(apiPagamento);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_RAGIONERIA, giornale)).isSameAs(apiRagioneria);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_BACKOFFICE, giornale)).isSameAs(apiBackoffice);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_PENDENZE, giornale)).isSameAs(apiPendenze);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_BACKEND_IO, giornale)).isSameAs(apiBackendIO);
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_MAGGIOLI_JPPA, giornale)).isSameAs(apiMaggioliJPPA);
+    }
+
+    @Test
+    @DisplayName("getConfigurazioneComponente should return null for unmapped components and null inputs")
+    void testGetConfigurazioneComponenteNullCases() {
+        Giornale giornale = new Giornale();
+
+        assertThat(gdeService.getConfigurazioneComponente(null, giornale)).isNull();
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.API_MAGGIOLI_JPPA, null)).isNull();
+        assertThat(gdeService.getConfigurazioneComponente(null, null)).isNull();
+        // Componente non mappato (default branch)
+        assertThat(gdeService.getConfigurazioneComponente(ComponenteEvento.GOVPAY, giornale)).isNull();
     }
 
     @Test


### PR DESCRIPTION
…1.0.2.

- GdeServiceTest: copertura del mapping ComponenteEvento->GdeInterfaccia e dei rami null (input null e default branch).
- RELEASE_NOTES.md: note di rilascio della versione 1.0.2.