### PR TITLE
Rimosse direttive logging.level.* da application.properties e avanzam…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-05-12  Giuliano Pintori <giuliano.pintori@link.it>
+
+	* Avanzamento versione 1.0.3
+
+	* [Config]
+	Rimosse le direttive logging.level.* da application.properties.
+	La configurazione di logging e' demandata al runtime (env, profili
+	dedicati, configurazione esterna). I livelli verbosi per i test
+	restano definiti in application-test.properties.
+
 2026-05-06  Giuliano Pintori <giuliano.pintori@link.it>
 
 	* [CI/CD]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 1.0.3 — 2026-05-12
+
+Release di manutenzione: pulizia della configurazione di logging.
+
+### Configurazione
+- Rimosse da `application.properties` le direttive `logging.level.*` (root, `it.govpay.maggioli.batch`, `org.springframework.batch`, `org.springframework.web.client`). La configurazione di logging è ora demandata al runtime (env, profili dedicati, configurazione esterna). I livelli verbosi per i test restano in `application-test.properties`.
+
+### Compatibilità
+Nessuna breaking change. In caso si volessero ripristinare i livelli precedenti, è sufficiente fornirli via variabili d'ambiente, `--logging.level.*` o profilo dedicato.
+
 ## 1.0.2 — 2026-05-06
 
 Release di manutenzione: aggiornamento dipendenze GovPay e potenziamento della pipeline di build/release.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>it.govpay</groupId>
     <artifactId>govpay-maggioli-jppa-batch</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>GovPay Maggioli JPPA Batch</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,9 +37,3 @@ govpay.batch.stale-threshold-minutes=120
 scheduler.maggioliJppaNotificationJob.fixedDelayString=600000
 # Initial delay before first execution (in milliseconds) - default 1ms
 scheduler.initialDelayString=1
-
-# Logging configuration
-logging.level.root=INFO
-logging.level.it.govpay.maggioli.batch=DEBUG
-logging.level.org.springframework.batch=INFO
-logging.level.org.springframework.web.client=DEBUG


### PR DESCRIPTION
…ento versione 1.0.3.

- application.properties: rimosse le 4 direttive logging.level.* (root, it.govpay.maggioli.batch, org.springframework.batch, org.springframework.web.client). La configurazione di logging e' demandata al runtime (env, profili, configurazione esterna).
- I livelli verbosi per i test restano in application-test.properties.
- Avanzamento versione progetto a 1.0.3.