### PR TITLE
Migrazione a Spring Boot 4 / Spring Framework 7 e avanzamento version…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,45 @@
+2026-07-11  Giuliano Pintori <giuliano.pintori@link.it>
+
+	* Avanzamento versione 2.0.0
+
+	* [Build]
+	Migrazione dello stack applicativo a Spring Boot 4 / Spring Framework 7:
+	- govpay-bom aggiornato dalla 1.1.3 alla 2.0.1 (Spring Boot 4.1.0,
+	  Spring Framework 7.0.8, Spring Batch 6.0.4, Hibernate 7.4.1,
+	  Jackson 3.1.4, Java 21)
+	- govpay-common aggiornato dalla 1.1.2 alla 2.0.0
+	- openapi-generator-maven-plugin aggiornato dalla 7.10.0 alla 7.23.0;
+	  client Maggioli generato per Spring Boot 4 / Jackson 3
+	  (serializationLibrary=jackson, useSpringBoot4=true, useJackson3=true)
+
+	* [Codice]
+	Migrazione Jackson 2 -> 3 (tools.jackson):
+	- WebConfig: ObjectMapper ricostruito con l'API builder immutabile
+	  (JsonMapper.builder, EnumFeature/DateTimeFeature)
+	- GdeService: ObjectMapper migrato a tools.jackson.databind.ObjectMapper
+
+	Migrazione Spring Batch 5 -> 6:
+	- Adeguati i package riorganizzati (core.job, core.step,
+	  core.job.parameters, core.listener, infrastructure.item,
+	  infrastructure.repeat) e la rinomina JobParametersInvalidException
+	  -> InvalidJobParametersException
+	- JobLauncher sostituito da JobOperator (run -> start) in
+	  BatchJobConfiguration e MaggioliJppaBatchScheduler
+	- JobExplorer sostituito da JobRepository in BatchController
+
+	Migrazione Spring Boot 4:
+	- @EntityScan spostato nel package boot.persistence.autoconfigure
+	- Nuova classe BatchInfraConfig: estratti da BatchJobConfiguration i
+	  bean taskExecutor, jobExecutionHelper e jobConcurrencyService per
+	  evitare la dipendenza circolare entityManagerFactory ->
+	  batchJobConfiguration -> transactionManager introdotta dal nuovo
+	  bootstrap JPA di Spring Boot 4
+
+	* [Test]
+	Adeguati i test alla nuova API (costruttore JobExecution di Spring
+	Batch 6, ObjectMapper Jackson 3, JobRepository al posto di JobExplorer).
+	Suite completa verde (85/85).
+
 2026-05-12  Giuliano Pintori <giuliano.pintori@link.it>
 
 	* Avanzamento versione 1.0.3

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 # Release Notes
 
+## 2.0.0 — 2026-07-11
+
+Major release: migrazione dello stack applicativo a **Spring Boot 4 / Spring Framework 7** (con Spring Batch 6, Hibernate 7, Jackson 3, Java 21).
+
+### Aggiornamenti dipendenze
+- `govpay-bom` aggiornato a **2.0.1** (parent BOM): Spring Boot **4.1.0**, Spring Framework **7.0.8**, Spring Batch **6.0.4**, Hibernate **7.4.1**, Jackson **3.1.4**, Java **21**.
+- `govpay-common` aggiornato a **2.0.0**.
+- `openapi-generator-maven-plugin` aggiornato a **7.23.0**; il client Maggioli è ora generato per Spring Boot 4 / Jackson 3 (`serializationLibrary=jackson`, `useSpringBoot4=true`, `useJackson3=true`).
+
+### Migrazione Jackson 2 → 3 (`tools.jackson`)
+- `WebConfig`: `ObjectMapper` ricostruito con l'API builder immutabile di Jackson 3 (`JsonMapper.builder()`, `EnumFeature`/`DateTimeFeature`), coerente con i serializer `OffsetDateTime` di `govpay-common` 2.0.0.
+- `GdeService`: `ObjectMapper` migrato a `tools.jackson.databind.ObjectMapper` (richiesto da `AbstractGdeService`).
+
+### Migrazione Spring Batch 5 → 6
+- Adeguati i package riorganizzati (`core.job`, `core.step`, `core.job.parameters`, `core.listener`, `infrastructure.item`, `infrastructure.repeat`) e la rinomina `JobParametersInvalidException` → `InvalidJobParametersException`.
+- `JobLauncher` sostituito da `JobOperator` (`run()` → `start()`) in `BatchJobConfiguration` e `MaggioliJppaBatchScheduler`.
+- `JobExplorer` sostituito da `JobRepository` in `BatchController`, allineato alle nuove firme di `AbstractBatchController` e `JobConcurrencyService`.
+
+### Migrazione Spring Boot 4
+- `@EntityScan` spostato nel package `org.springframework.boot.persistence.autoconfigure`.
+- Nuova classe `BatchInfraConfig`: i bean infrastrutturali (`taskExecutor`, `jobExecutionHelper`, `jobConcurrencyService`) sono stati estratti da `BatchJobConfiguration` per evitare la dipendenza circolare `entityManagerFactory → batchJobConfiguration → transactionManager` introdotta dal nuovo bootstrap JPA di Spring Boot 4.
+
+### Compatibilità
+Release major con **breaking change** infrastrutturali: richiede Java 21 a runtime e l'ecosistema GovPay allineato al BOM 2.x (`govpay-common` 2.0.0). Nessuna modifica al comportamento funzionale del batch di notifica.
+
 ## 1.0.3 — 2026-05-12
 
 Release di manutenzione: pulizia della configurazione di logging.

--- a/pom.xml
+++ b/pom.xml
@@ -8,21 +8,21 @@
     <parent>
         <groupId>org.gov4j.govpay</groupId>
         <artifactId>govpay-bom</artifactId>
-        <version>1.1.3</version>
+        <version>2.0.1</version>
         <relativePath/>
     </parent>
 
     <groupId>it.govpay</groupId>
     <artifactId>govpay-maggioli-jppa-batch</artifactId>
-    <version>1.0.3</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>GovPay Maggioli JPPA Batch</name>
     <description>Batch di notifiche pagamenti ai servizi Maggioli</description>
 
     <properties>
-        <govpay-common.version>1.1.2</govpay-common.version>
-        <openapi-generator.version>7.10.0</openapi-generator.version>
+        <govpay-common.version>2.0.0</govpay-common.version>
+        <openapi-generator.version>7.23.0</openapi-generator.version>
 
         <!-- Code Coverage -->
         <jacoco.version>0.8.13</jacoco.version>
@@ -311,6 +311,9 @@
                                 <performBeanValidation>true</performBeanValidation>
                                 <serializableModel>true</serializableModel>
                                 <openApiNullable>false</openApiNullable>
+                                <serializationLibrary>jackson</serializationLibrary>
+                                <useSpringBoot4>true</useSpringBoot4>
+                                <useJackson3>true</useJackson3>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/src/main/java/it/govpay/maggioli/batch/GovpayMaggioliBatchApplication.java
+++ b/src/main/java/it/govpay/maggioli/batch/GovpayMaggioliBatchApplication.java
@@ -2,7 +2,7 @@ package it.govpay.maggioli.batch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/it/govpay/maggioli/batch/config/BatchInfraConfig.java
+++ b/src/main/java/it/govpay/maggioli/batch/config/BatchInfraConfig.java
@@ -1,0 +1,57 @@
+package it.govpay.maggioli.batch.config;
+
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+import it.govpay.common.batch.runner.JobExecutionHelper;
+import it.govpay.common.batch.service.JobConcurrencyService;
+
+/**
+ * Dichiarazione esplicita dei bean infrastrutturali per la gestione batch
+ * multi-nodo forniti da {@code govpay-common} ({@link JobExecutionHelper} e
+ * {@link JobConcurrencyService}).
+ * <p>
+ * Sono tenuti separati da {@link BatchJobConfiguration} (che inietta
+ * {@code PlatformTransactionManager}) per evitare la dipendenza circolare
+ * {@code entityManagerFactory -> batchJobConfiguration -> transactionManager ->
+ * entityManagerFactory} introdotta da Spring Batch 6 / Spring Boot 4.
+ */
+@Configuration
+public class BatchInfraConfig {
+
+    private final BatchProperties batchProperties;
+
+    public BatchInfraConfig(BatchProperties batchProperties) {
+        this.batchProperties = batchProperties;
+    }
+
+    @Bean
+    public JobConcurrencyService jobConcurrencyService(JobRepository jobRepository) {
+        return new JobConcurrencyService(jobRepository, batchProperties.getStaleThresholdMinutes());
+    }
+
+    @Bean
+    public JobExecutionHelper jobExecutionHelper(JobOperator jobOperator, JobConcurrencyService jobConcurrencyService) {
+        return new JobExecutionHelper(jobOperator, jobConcurrencyService,
+            batchProperties.getClusterId(), batchProperties.getZoneId());
+    }
+
+    /**
+     * Task executor per l'elaborazione parallela degli step di batch.
+     * <p>
+     * Definito qui (config priva di dipendenze su {@code PlatformTransactionManager})
+     * e non in {@link BatchJobConfiguration}: in Spring Boot 4 l'
+     * {@code entityManagerFactoryBuilder} risolve un {@code ObjectProvider<AsyncTaskExecutor>}
+     * per il bootstrap, e trovarlo dentro {@code BatchJobConfiguration} innescherebbe
+     * la dipendenza circolare con l'{@code entityManagerFactory}.
+     */
+    @Bean
+    public SimpleAsyncTaskExecutor taskExecutor() {
+        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("maggioli-batch-");
+        executor.setConcurrencyLimit(batchProperties.getThreadPoolSize());
+        return executor;
+    }
+}

--- a/src/main/java/it/govpay/maggioli/batch/config/BatchJobConfiguration.java
+++ b/src/main/java/it/govpay/maggioli/batch/config/BatchJobConfiguration.java
@@ -12,20 +12,16 @@ import it.govpay.maggioli.batch.step3.SendNotificationProcessor;
 import it.govpay.maggioli.batch.step3.SendNotificationReader;
 import it.govpay.maggioli.batch.step3.SendNotificationWriter;
 import it.govpay.maggioli.batch.tasklet.CleanupJppaNotificheTasklet;
-import it.govpay.common.batch.runner.JobExecutionHelper;
-import it.govpay.common.batch.service.JobConcurrencyService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.job.parameters.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.context.annotation.Bean;
@@ -84,17 +80,6 @@ public class BatchJobConfiguration {
         return backOffPolicy;
 	}
 
-    @Bean
-    public JobConcurrencyService jobConcurrencyService(JobExplorer jobExplorer) {
-        return new JobConcurrencyService(jobExplorer, jobRepository, batchProperties.getStaleThresholdMinutes());
-    }
-
-    @Bean
-    public JobExecutionHelper jobExecutionHelper(JobLauncher jobLauncher, JobConcurrencyService jobConcurrencyService) {
-        return new JobExecutionHelper(jobLauncher, jobConcurrencyService,
-            batchProperties.getClusterId(), batchProperties.getZoneId());
-    }
-
     /**
      * Main Maggioli JPPA Notification Job with 2 steps
      */
@@ -131,7 +116,8 @@ public class BatchJobConfiguration {
     public Step maggioliHeadersAcquisitionStep(
         MaggioliJppaHeadersReader maggioliHeadersReader,
         MaggioliJppaHeadersProcessor maggioliHeadersProcessor,
-        MaggioliJppaHeadersWriter maggioliHeadersWriter
+        MaggioliJppaHeadersWriter maggioliHeadersWriter,
+        SimpleAsyncTaskExecutor taskExecutor
     ) {
         return new StepBuilder("maggioliHeadersAcquisitionStep", jobRepository)
             .<DominioProcessingContext, MaggioliHeadersBatch>chunk(batchProperties.getChunkSize(), transactionManager)
@@ -139,7 +125,7 @@ public class BatchJobConfiguration {
             .processor(maggioliHeadersProcessor)
             .writer(maggioliHeadersWriter)
             .listener(maggioliHeadersReader) // Register reader as step listener for queue reset
-            .taskExecutor(taskExecutor())
+            .taskExecutor(taskExecutor)
             .build();
     }
 
@@ -180,13 +166,14 @@ public class BatchJobConfiguration {
     @Bean
     public Step maggioliSendNotificationStep(
         DominioPartitioner dominioPartitioner,
-        Step maggioliSendNotificationWorkerStep
+        Step maggioliSendNotificationWorkerStep,
+        SimpleAsyncTaskExecutor taskExecutor
     ) {
         return new StepBuilder("maggioliSendNotificationStep", jobRepository)
             .partitioner("sendNotificationWorkerStep", dominioPartitioner)
             .step(maggioliSendNotificationWorkerStep)
             .gridSize(batchProperties.getThreadPoolSize()) // Numero di partizioni parallele
-            .taskExecutor(taskExecutor())
+            .taskExecutor(taskExecutor)
             .build();
     }
 
@@ -214,16 +201,6 @@ public class BatchJobConfiguration {
             .retry(RestClientException.class)
             .listener(sendNotificationRetryListener)
             .build();
-    }
-
-    /**
-     * Task executor for parallel processing in Step 2
-     */
-    @Bean
-    public SimpleAsyncTaskExecutor taskExecutor() {
-        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("maggioli-batch-");
-        executor.setConcurrencyLimit(batchProperties.getThreadPoolSize());
-        return executor;
     }
 
 }

--- a/src/main/java/it/govpay/maggioli/batch/config/CronJobRunner.java
+++ b/src/main/java/it/govpay/maggioli/batch/config/CronJobRunner.java
@@ -1,6 +1,6 @@
 package it.govpay.maggioli.batch.config;
 
-import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.Job;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;

--- a/src/main/java/it/govpay/maggioli/batch/config/ScheduledJobRunner.java
+++ b/src/main/java/it/govpay/maggioli/batch/config/ScheduledJobRunner.java
@@ -1,11 +1,11 @@
 package it.govpay.maggioli.batch.config;
 
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobParametersInvalidException;
-import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
-import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
-import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobRestartException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -32,7 +32,7 @@ public class ScheduledJobRunner extends AbstractScheduledJobRunner {
         initialDelayString = "${scheduler.initialDelayString:1}"
     )
     public JobExecution runBatchMaggioliJppaNotificationJob() throws JobExecutionAlreadyRunningException,
-            JobRestartException, JobInstanceAlreadyCompleteException, JobParametersInvalidException {
+            JobRestartException, JobInstanceAlreadyCompleteException, InvalidJobParametersException {
         return executeScheduledJob();
     }
 }

--- a/src/main/java/it/govpay/maggioli/batch/config/WebConfig.java
+++ b/src/main/java/it/govpay/maggioli/batch/config/WebConfig.java
@@ -8,10 +8,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 import it.govpay.common.utils.DateTimePatterns;
 import it.govpay.common.utils.OffsetDateTimeDeserializer;
@@ -25,25 +26,20 @@ public class WebConfig {
 
 	@Bean
 	public ObjectMapper objectMapper() {
-		ObjectMapper objectMapper = new ObjectMapper();
+		// Registra serializzatori/deserializzatori custom per OffsetDateTime
+		SimpleModule dateModule = new SimpleModule();
+		dateModule.addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
+		dateModule.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
 
-		objectMapper.setTimeZone(TimeZone.getTimeZone(timezone));
-
-		objectMapper.setDateFormat(
-			new SimpleDateFormat(DateTimePatterns.PATTERN_TIMESTAMP_3_YYYY_MM_DD_T_HH_MM_SS_SSSXXX)
-		);
-
-		objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-		objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-
-		objectMapper.enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID);
-		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-		JavaTimeModule javaTimeModule = new JavaTimeModule();
-		javaTimeModule.addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
-		javaTimeModule.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
-		objectMapper.registerModule(javaTimeModule);
-
-		return objectMapper;
+		// Jackson 3: ObjectMapper e' immutabile, la configurazione avviene tramite builder.
+		return JsonMapper.builder()
+			.defaultTimeZone(TimeZone.getTimeZone(timezone))
+			.defaultDateFormat(new SimpleDateFormat(DateTimePatterns.PATTERN_TIMESTAMP_3_YYYY_MM_DD_T_HH_MM_SS_SSSXXX))
+			.addModule(dateModule)
+			.enable(EnumFeature.READ_ENUMS_USING_TO_STRING)
+			.enable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
+			.enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.build();
 	}
 }

--- a/src/main/java/it/govpay/maggioli/batch/controller/BatchController.java
+++ b/src/main/java/it/govpay/maggioli/batch/controller/BatchController.java
@@ -2,8 +2,8 @@ package it.govpay.maggioli.batch.controller;
 
 import java.time.ZoneId;
 
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
@@ -30,13 +30,13 @@ public class BatchController extends AbstractBatchController {
 
     public BatchController(
             JobExecutionHelper jobExecutionHelper,
-            JobExplorer jobExplorer,
+            JobRepository jobRepository,
             @Qualifier("maggioliJppaNotificationJob") Job maggioliJppaNotificationJob,
             Environment environment,
             ZoneId applicationZoneId,
             @Value("${scheduler.maggioliJppaNotificationJob.fixedDelayString:600000}") long schedulerIntervalMillis,
             ConnettoreService connettoreService) {
-        super(jobExecutionHelper, jobExplorer, environment, applicationZoneId, schedulerIntervalMillis);
+        super(jobExecutionHelper, jobRepository, environment, applicationZoneId, schedulerIntervalMillis);
         this.maggioliJppaNotificationJob = maggioliJppaNotificationJob;
         this.connettoreService = connettoreService;
     }

--- a/src/main/java/it/govpay/maggioli/batch/gde/service/GdeService.java
+++ b/src/main/java/it/govpay/maggioli/batch/gde/service/GdeService.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.common.client.gde.HttpDataHolder;
 import it.govpay.common.configurazione.model.GdeInterfaccia;

--- a/src/main/java/it/govpay/maggioli/batch/listener/BatchExecutionRecapListener.java
+++ b/src/main/java/it/govpay/maggioli/batch/listener/BatchExecutionRecapListener.java
@@ -1,7 +1,7 @@
 package it.govpay.maggioli.batch.listener;
 
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.step.StepExecution;
 import org.springframework.stereotype.Component;
 
 import it.govpay.common.batch.listener.AbstractBatchExecutionListener;

--- a/src/main/java/it/govpay/maggioli/batch/partitioner/DominioPartitioner.java
+++ b/src/main/java/it/govpay/maggioli/batch/partitioner/DominioPartitioner.java
@@ -4,8 +4,8 @@ import it.govpay.maggioli.batch.entity.JppaConfig;
 import it.govpay.maggioli.batch.repository.JppaConfigRepository;
 import it.govpay.maggioli.batch.repository.JppaNotificheRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.partition.support.Partitioner;
-import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.core.partition.Partitioner;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/src/main/java/it/govpay/maggioli/batch/scheduler/MaggioliJppaBatchScheduler.java
+++ b/src/main/java/it/govpay/maggioli/batch/scheduler/MaggioliJppaBatchScheduler.java
@@ -1,10 +1,10 @@
 package it.govpay.maggioli.batch.scheduler;
 
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -19,14 +19,14 @@ import lombok.extern.slf4j.Slf4j;
 @ConditionalOnProperty(prefix = "govpay.batch", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class MaggioliJppaBatchScheduler {
 
-    private final JobLauncher jobLauncher;
+    private final JobOperator jobOperator;
     private final Job maggioliJppaNotificationJob;
 
     public MaggioliJppaBatchScheduler(
-        JobLauncher jobLauncher,
+        JobOperator jobOperator,
         Job maggioliJppaNotificationJob
     ) {
-        this.jobLauncher = jobLauncher;
+        this.jobOperator = jobOperator;
         this.maggioliJppaNotificationJob = maggioliJppaNotificationJob;
     }
 
@@ -43,7 +43,7 @@ public class MaggioliJppaBatchScheduler {
                 .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
-            res = jobLauncher.run(maggioliJppaNotificationJob, jobParameters);
+            res = jobOperator.start(maggioliJppaNotificationJob, jobParameters);
 
             log.info("Maggioli JPPA Notification Job completed successfully");
 

--- a/src/main/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersProcessor.java
+++ b/src/main/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersProcessor.java
@@ -5,7 +5,7 @@ import it.govpay.maggioli.batch.dto.DominioProcessingContext;
 import it.govpay.maggioli.batch.dto.MaggioliHeadersBatch;
 import it.govpay.maggioli.batch.repository.RptRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 

--- a/src/main/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersReader.java
+++ b/src/main/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersReader.java
@@ -2,10 +2,10 @@ package it.govpay.maggioli.batch.step2;
 
 import java.util.List;
 
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.listener.StepExecutionListener;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.stereotype.Component;
 
 import it.govpay.maggioli.batch.dto.DominioProcessingContext;

--- a/src/main/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersWriter.java
+++ b/src/main/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersWriter.java
@@ -4,8 +4,8 @@ import it.govpay.maggioli.batch.dto.MaggioliHeadersBatch;
 import it.govpay.maggioli.batch.entity.JppaNotifiche;
 import it.govpay.maggioli.batch.repository.JppaNotificheRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.item.Chunk;
-import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/it/govpay/maggioli/batch/step3/SendNotificationProcessor.java
+++ b/src/main/java/it/govpay/maggioli/batch/step3/SendNotificationProcessor.java
@@ -9,7 +9,7 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;

--- a/src/main/java/it/govpay/maggioli/batch/step3/SendNotificationReader.java
+++ b/src/main/java/it/govpay/maggioli/batch/step3/SendNotificationReader.java
@@ -4,10 +4,10 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.ItemReader;
-import org.springframework.batch.item.ItemStream;
-import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.batch.infrastructure.item.ItemStream;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/it/govpay/maggioli/batch/step3/SendNotificationWriter.java
+++ b/src/main/java/it/govpay/maggioli/batch/step3/SendNotificationWriter.java
@@ -21,11 +21,11 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.csv.CSVFormat;
 import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.listener.StepExecutionListener;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.Chunk;
-import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/it/govpay/maggioli/batch/tasklet/CleanupJppaNotificheTasklet.java
+++ b/src/main/java/it/govpay/maggioli/batch/tasklet/CleanupJppaNotificheTasklet.java
@@ -2,10 +2,10 @@ package it.govpay.maggioli.batch.tasklet;
 
 import it.govpay.maggioli.batch.repository.JppaNotificheRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.step.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/it/govpay/maggioli/batch/GovpayMaggioliBatchRetryTests.java
+++ b/src/test/java/it/govpay/maggioli/batch/GovpayMaggioliBatchRetryTests.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.explore.JobExplorer;
-import org.springframework.batch.item.Chunk;
-import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -69,7 +69,7 @@ class GovpayMaggioliBatchRetryTests {
 	private static final String ESITO_OK_TEST = EsitoEnum.OK.name();
 
 	@Autowired
-	JobExplorer jobExplorer;
+	JobRepository jobRepository;
 
 	@Autowired
 	MaggioliJppaBatchScheduler batchScheduler;

--- a/src/test/java/it/govpay/maggioli/batch/config/CronJobRunnerTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/config/CronJobRunnerTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.Job;
 
 import it.govpay.common.batch.runner.JobExecutionHelper;
 

--- a/src/test/java/it/govpay/maggioli/batch/config/ScheduledJobRunnerTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/config/ScheduledJobRunnerTest.java
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
 
 import it.govpay.common.batch.runner.JobExecutionHelper;
 import it.govpay.common.batch.runner.JobExecutionHelper.PreExecutionCheckResult;
@@ -65,7 +66,7 @@ class ScheduledJobRunnerTest {
         when(jobExecutionHelper.checkBeforeExecution(JOB_NAME))
             .thenReturn(new PreExecutionResult(PreExecutionCheckResult.CAN_PROCEED, null, null));
 
-        JobExecution launched = new JobExecution(2L);
+        JobExecution launched = new JobExecution(2L, new JobInstance(1L, JOB_NAME), new JobParameters());
         when(jobExecutionHelper.runJob(eq(maggioliJppaNotificationJob), eq(JOB_NAME)))
             .thenReturn(launched);
 
@@ -80,7 +81,7 @@ class ScheduledJobRunnerTest {
         when(jobExecutionHelper.checkBeforeExecution(JOB_NAME))
             .thenReturn(new PreExecutionResult(PreExecutionCheckResult.STALE_ABANDONED_CAN_PROCEED, null, null));
 
-        JobExecution launched = new JobExecution(2L);
+        JobExecution launched = new JobExecution(2L, new JobInstance(1L, JOB_NAME), new JobParameters());
         when(jobExecutionHelper.runJob(eq(maggioliJppaNotificationJob), eq(JOB_NAME)))
             .thenReturn(launched);
 

--- a/src/test/java/it/govpay/maggioli/batch/gde/service/GdeServiceTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/gde/service/GdeServiceTest.java
@@ -23,7 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.common.client.model.Connettore;
 import it.govpay.common.configurazione.model.GdeInterfaccia;

--- a/src/test/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersWriterTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/step2/MaggioliJppaHeadersWriterTest.java
@@ -20,7 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.batch.item.Chunk;
+import org.springframework.batch.infrastructure.item.Chunk;
 
 import it.govpay.maggioli.batch.dto.MaggioliHeadersBatch;
 import it.govpay.maggioli.batch.entity.JppaNotifiche;

--- a/src/test/java/it/govpay/maggioli/batch/step3/SendNotificationReaderTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/step3/SendNotificationReaderTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
 
 import it.govpay.maggioli.batch.Costanti;
 import it.govpay.maggioli.batch.entity.RPT;

--- a/src/test/java/it/govpay/maggioli/batch/step3/SendNotificationWriterTest.java
+++ b/src/test/java/it/govpay/maggioli/batch/step3/SendNotificationWriterTest.java
@@ -33,8 +33,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.item.Chunk;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.Chunk;
 import org.springframework.mail.MailSendException;
 
 import it.govpay.common.client.service.ConnettoreService;


### PR DESCRIPTION
…e 2.0.0.

- govpay-bom 1.1.3 -> 2.0.1 (Spring Boot 4.1.0, Spring Framework 7.0.8, Spring Batch 6.0.4, Hibernate 7.4.1, Jackson 3.1.4, Java 21).
- govpay-common 1.1.2 -> 2.0.0; openapi-generator 7.10.0 -> 7.23.0 (useSpringBoot4/useJackson3 per il client Maggioli).
- Jackson 2 -> 3 (tools.jackson): WebConfig ricostruito con JsonMapper.builder, GdeService su tools.jackson.databind.ObjectMapper.
- Spring Batch 6: nuovi package core.job/step/parameters/listener e infrastructure.item/repeat, JobParametersInvalidException -> InvalidJobParametersException, JobLauncher -> JobOperator, JobExplorer -> JobRepository.
- Spring Boot 4: @EntityScan in boot.persistence.autoconfigure; nuova BatchInfraConfig per estrarre taskExecutor/jobExecutionHelper/jobConcurrencyService da BatchJobConfiguration ed evitare la dipendenza circolare con entityManagerFactory.
- Adeguati i test; suite verde (85/85).